### PR TITLE
v0.5.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ LCS remove the different token values ​​from the two responses as follows:
   
 [See Details](https://github.com/gdgd009xcd/CustomActiveScanForZAP/wiki/99.1.-SQL-injection-detection-test-results-with-ActiveScan)
 
+## Prerequisite
+
+* OWASP ZAP ver 2.11.0 or later
 
 ## Download & Building
 

--- a/addOns/customactivescan/CHANGELOG.md
+++ b/addOns/customactivescan/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+## 12 - 2021-12-15
+### v0.5.6
+- maintenance: removed the log4j2 library that this add-on contains
+- maintenance: upgraded OWASP ZAP dependency version  to 2.11.0
+
 ## 11 - 2021-12-11
 ### v0.5.5
 - bugfix: There were false positive in the judgement code in 3-1,3-2

--- a/addOns/customactivescan/customactivescan.gradle.kts
+++ b/addOns/customactivescan/customactivescan.gradle.kts
@@ -1,6 +1,6 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
-version = "0.5.5"
+version = "0.5.6"
 description = "a Active Scanner with custmizable rules"
 
 val jar by tasks.getting(Jar::class) {
@@ -12,7 +12,7 @@ val jar by tasks.getting(Jar::class) {
 zapAddOn {
     addOnName.set("CustomActiveScanForZAP")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.8.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("gdgd009xcd")
@@ -26,8 +26,6 @@ zapAddOn {
 
 dependencies {
     implementation("com.google.code.gson:gson:2.8.6")
-    implementation("org.apache.logging.log4j:log4j-core:2.15.0")
-
     testImplementation("org.apache.commons:commons-lang3:3.9")
 }
 

--- a/addOns/customactivescan/src/main/java/org/zaproxy/zap/extension/customactivescan/CustomSQLInjectionScanRule.java
+++ b/addOns/customactivescan/src/main/java/org/zaproxy/zap/extension/customactivescan/CustomSQLInjectionScanRule.java
@@ -608,10 +608,17 @@ public class CustomSQLInjectionScanRule extends AbstractAppParamPlugin {
 
         //raise the alert, and save the attack string for the "Authentication Bypass" alert, if necessary
         String sqlInjectionAttack = "true[" + extraTrueValue +"]false[" + extraFalseValue + "]" + (errorValue == null ? "" : "error[" + errorValue + "]");
-        bingo(risk, confidence, getName(), getDescription(),
-                null, //url
-                origParamName, sqlInjectionAttack,
-                extraInfo, getSolution(), evidence, message);
+
+        newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setParam(origParamName)
+                .setAttack(sqlInjectionAttack)
+                .setOtherInfo(extraInfo)
+                .setEvidence(evidence)
+                .setMessage(message)
+                .raise();
+
     }
 
     /**
@@ -658,10 +665,16 @@ public class CustomSQLInjectionScanRule extends AbstractAppParamPlugin {
         String sqlInjectionAttack = (extraTrueValue == null ? "" : "true[" + extraTrueValue + "] ")
                 + (extraFalseValue == null ? "" : "false[" + extraFalseValue + "] ")
                 + (extraErrorValue == null ? "" : "error[" + extraErrorValue + "]");
-        bingo(risk, confidence, getName(), getDescription(),
-                null, //url
-                origParamName, sqlInjectionAttack,
-                extraInfo, getSolution(), evidence, message);
+
+        newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setParam(origParamName)
+                .setAttack(sqlInjectionAttack)
+                .setOtherInfo(extraInfo)
+                .setEvidence(evidence)
+                .setMessage(message)
+                .raise();
     }
 
     /**

--- a/addOns/customactivescan/src/main/java/org/zaproxy/zap/extension/customactivescan/ExtensionAscanRules.java
+++ b/addOns/customactivescan/src/main/java/org/zaproxy/zap/extension/customactivescan/ExtensionAscanRules.java
@@ -19,7 +19,7 @@
 package org.zaproxy.zap.extension.customactivescan;
 
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LoggerContext;
+// import org.apache.logging.log4j.core.LoggerContext;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -75,6 +75,7 @@ public class ExtensionAscanRules extends ExtensionAdaptor {
 	@Override
 	public void hook(ExtensionHook hook) {
 		super.hook(hook);
+		/**
 		File log4jdir =
 				new File(ZAPHOME_DIR); // $HOME/.ZAP or $HOME/.ZAP_D
 		String fileName = "log4j2.xml";
@@ -91,5 +92,6 @@ public class ExtensionAscanRules extends ExtensionAdaptor {
 		} else {
 			System.out.println("log4j file not found.:" + logFile.getPath());
 		}
+		 **/
 	}
 }


### PR DESCRIPTION
- maintenance: removed the log4j2 library that this add-on contains
- maintenance: upgraded OWASP ZAP dependency version  to 2.11.0